### PR TITLE
Allow setting the resource class when building system

### DIFF
--- a/src/jobs/build-system.yml
+++ b/src/jobs/build-system.yml
@@ -1,7 +1,11 @@
 parameters:
   exec:
     type: executor
+  resource-class:
+    type: string
+    default: medium
 executor: << parameters.exec >>
+resource_class: << parameters.resource-class >>
 steps:
   - checkout
   - install-elixir:


### PR DESCRIPTION
This is useful for building kiosk systems since they take more than the default resources to build.