### PR TITLE
Allow env-setup steps when building

### DIFF
--- a/src/jobs/build-system.yml
+++ b/src/jobs/build-system.yml
@@ -7,10 +7,14 @@ parameters:
   hex-validate:
     type: boolean
     default: true
+  env-setup:
+    type: steps
+    default: []
 executor: << parameters.exec >>
 resource_class: << parameters.resource-class >>
 steps:
   - checkout
+  - steps: << parameters.env-setup >>
   - install-elixir:
       version: $ELIXIR_VERSION
   - install-hex-rebar


### PR DESCRIPTION
Some systems may require more specific setup in the image when compiling. This allows you to specify those steps

```
workflows:
  version: 2
  build_test_deploy:
    jobs:
      - build-tools/build-system:
           exec:
             <<: *exec
           env-setup:
             - run: apt-get install something_else
             - run: apt-get install another_thing
```