### PR TITLE
Change dl.nerves-project.org to use http

### DIFF
--- a/src/jobs/get-br-dependencies.yml
+++ b/src/jobs/get-br-dependencies.yml
@@ -30,7 +30,7 @@ parameters:
     default: false
   download-site-url:
     type: string
-    default: https://dl.nerves-project.org
+    default: http://dl.nerves-project.org
 executor: << parameters.exec >>
 resource_class: << parameters.resource-class >>
 steps:


### PR DESCRIPTION
This fixes certificate errors when downloads. This is ok since Buildroot
checks SHAs on the downloaded tarballs to protect against supply chain
attacks.
