### PR TITLE
Enable download site with environment variable instead of CI parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ The Nerves project maintains a package download site. This orb will use it by se
 
 This orb can push new packages to the download site for future builds. Only AWS S3 is supported. To use this feature, you will need to set parameters as environment variables in CircleCI:
 
-- Add `push-to-download-site: true` to the `build-tools/get-br-dependencies` job.
-- Add `download-site-url: https://<download-site-url>` and set it to the public
-  URL of the S3 bucket. The steps to create the bucket are below.
+- Add `download-site-url: https://<download-site-url>` to the
+  `build-tools/get-br-dependencies` job and set it to the public URL of the S3
+  bucket. The steps to create the bucket are below.
 
 ```yaml
 workflows:
@@ -100,7 +100,6 @@ workflows:
       - build-tools/get-br-dependencies:
           exec:
             <<: *exec
-          push-to-download-site: true
           download-site-url: https://<bucket-name>.s3.amazonaws.com
 ```
 
@@ -131,6 +130,7 @@ workflows:
   - `AWS_SECRET_ACCESS_KEY`
   - `AWS_REGION`
   - `DOWNLOAD_SITE_BUCKET_URI` (`s3://<bucket-name>/`)
+  - `PUSH_TO_DOWNLOAD_SITE` (`true`)
 
 - If you would like your Nerves system to pull packages from the download site
   when building outside of CI, set the Buildroot primary site in your Nerves

--- a/src/jobs/get-br-dependencies.yml
+++ b/src/jobs/get-br-dependencies.yml
@@ -13,6 +13,9 @@ parameters:
   download-site-bucket-uri:
     type: env_var_name
     default: DOWNLOAD_SITE_BUCKET_URI
+  push-to-download-site:
+    type: env_var_name
+    default: PUSH_TO_DOWNLOAD_SITE
   resource-class:
     type: string
     default: medium
@@ -25,9 +28,6 @@ parameters:
   save-dl-cache:
     type: boolean
     default: true
-  push-to-download-site:
-    type: boolean
-    default: false
   download-site-url:
     type: string
     default: http://dl.nerves-project.org
@@ -40,18 +40,17 @@ steps:
       version: $ELIXIR_VERSION
   - install-hex-rebar
   - install-nerves-bootstrap
-  - when:
-      condition: << parameters.push-to-download-site >>
-      steps:
-      - run:
-          name: Install AWS CLI
-          command: |
-            apt install -y python3-pip
-            pip install awscli
+  - run:
+      name: Install AWS CLI
+      command: |
+        [[ -z "${PUSH_TO_DOWNLOAD_SITE}" ]] && echo "Skipped" && exit 0
 
-            aws configure set aws_access_key_id ${<< parameters.aws-access-key-id >>}
-            aws configure set aws_secret_access_key ${<< parameters.aws-secret-access-key >>}
-            aws configure set region ${<< parameters.aws-region >>}
+        apt install -y python3-pip
+        pip install awscli
+
+        aws configure set aws_access_key_id ${<< parameters.aws-access-key-id >>}
+        aws configure set aws_secret_access_key ${<< parameters.aws-secret-access-key >>}
+        aws configure set region ${<< parameters.aws-region >>}
   - mix-deps-get
   - restore-nerves-downloads
   - when:
@@ -60,24 +59,17 @@ steps:
         - run:
             name: Validate Hex package
             command: mix hex.build
-  - when:
-      condition: << parameters.push-to-download-site >>
-      steps:
-        - run:
-            name: Get Buildroot dependencies [<< parameters.download-site-url >>]
-            command: |
-              ./deps/nerves_system_br/create-build.sh nerves_defconfig ~/temp_nerves_system
-              cd ~/temp_nerves_system
-              make BR2_PRIMARY_SITE=<< parameters.download-site-url >> BR2_BACKUP_SITE=http://sources.buildroot.net source
-  - unless:
-      condition: << parameters.push-to-download-site >>
-      steps:
-        - run:
-            name: Get Buildroot dependencies [source]
-            command: |
-              ./deps/nerves_system_br/create-build.sh nerves_defconfig ~/temp_nerves_system
-              cd ~/temp_nerves_system
-              make source
+  - run:
+      name: Get Buildroot dependencies
+      command: |
+        ./deps/nerves_system_br/create-build.sh nerves_defconfig ~/temp_nerves_system
+        cd ~/temp_nerves_system
+
+        if [[ -n "${PUSH_TO_DOWNLOAD_SITE}" ]]; then
+          make BR2_PRIMARY_SITE=<< parameters.download-site-url >> BR2_BACKUP_SITE=http://sources.buildroot.net source
+        else
+          make source
+        fi
   - when:
       condition: << parameters.save-dl-cache >>
       steps:
@@ -86,9 +78,8 @@ steps:
           key: nerves-dl-{{ .Branch }}-{{ .Revision }}
           paths:
             - "~/.nerves/dl"
-  - when:
-      condition: << parameters.push-to-download-site >>
-      steps:
-      - run:
-          name: Push new packages to download site
-          command: aws s3 sync ~/.nerves/dl ${<< parameters.download-site-bucket-uri >>} --exclude "*" --include "*.tar.*" --include "*.patch.*" --include "*.patch" --include "*-patch.*" --exclude ".lock" --exclude "*git/*"
+  - run:
+      name: Push new packages to download site
+      command: |
+        [[ -z "${PUSH_TO_DOWNLOAD_SITE}" ]] && echo "Skipped" && exit 0
+        aws s3 sync ~/.nerves/dl ${<< parameters.download-site-bucket-uri >>} --exclude "*" --include "*.tar.*" --include "*.patch.*" --include "*.patch" --include "*-patch.*" --exclude ".lock" --exclude "*git/*"


### PR DESCRIPTION
This PR converts the `push-to-download-site` CI parameter to the `PUSH_TO_DOWNLOAD_SITE` environment variable. This allows people to fork Nerves systems without needing to update the CI config afterwards. Unfortunately the CI parameters are evaluated at compile time and therefore don't work as expected in the CI conditional statements. To work around this, the conditionals have been moved into the commands for these steps.