### PR TITLE
Don't require root when installing Elixir

### DIFF
--- a/src/commands/install-elixir.yml
+++ b/src/commands/install-elixir.yml
@@ -2,10 +2,13 @@ description: Install Elixir
 parameters:
   version:
     type: string
+  install_path:
+    type: string
+    default: $HOME/elixir
 steps:
   - run:
       name: Install Elixir
       command: |
         wget https://repo.hex.pm/builds/elixir/v<< parameters.version >>.zip
-        unzip -d $HOME/elixir v<< parameters.version >>.zip
-        echo 'export PATH=$HOME/elixir/bin:$PATH' >> $BASH_ENV
+        unzip -d << parameters.install_path >> v<< parameters.version >>.zip
+        echo 'export PATH=<< parameters.install_path >>/bin:$PATH' >> $BASH_ENV

--- a/src/commands/install-elixir.yml
+++ b/src/commands/install-elixir.yml
@@ -7,5 +7,5 @@ steps:
       name: Install Elixir
       command: |
         wget https://repo.hex.pm/builds/elixir/v<< parameters.version >>.zip
-        unzip -d /usr/local/elixir v<< parameters.version >>.zip
-        echo 'export PATH=/usr/local/elixir/bin:$PATH' >> $BASH_ENV
+        unzip -d $HOME/elixir v<< parameters.version >>.zip
+        echo 'export PATH=$HOME/elixir/bin:$PATH' >> $BASH_ENV


### PR DESCRIPTION
This moves the Elixir installation directory to the home directory to
avoid running into permissions issues now that the builds don't run as
root by default.
