### PR TITLE
Reverse order of dep fetch and Nerves downloads

### DIFF
--- a/src/jobs/get-br-dependencies.yml
+++ b/src/jobs/get-br-dependencies.yml
@@ -51,8 +51,8 @@ steps:
         aws configure set aws_access_key_id ${<< parameters.aws-access-key-id >>}
         aws configure set aws_secret_access_key ${<< parameters.aws-secret-access-key >>}
         aws configure set region ${<< parameters.aws-region >>}
-  - mix-deps-get
   - restore-nerves-downloads
+  - mix-deps-get
   - when:
       condition: << parameters.hex-validate >>
       steps:


### PR DESCRIPTION
Resolves #16

@ringlej pointed out that switching this order to could save a few seconds in build time as the toolchain is stored is the same path that `restore-nerves-downloads` is restoring which means the toolchain will not need to be downloaded again when calling `mix deps.get`