### PR TITLE
Use double-quotes with echo in `install-elixir`

### DIFF
--- a/src/commands/install-elixir.yml
+++ b/src/commands/install-elixir.yml
@@ -11,4 +11,4 @@ steps:
       command: |
         wget https://repo.hex.pm/builds/elixir/v<< parameters.version >>.zip
         unzip -d << parameters.install_path >> v<< parameters.version >>.zip
-        echo 'export PATH=<< parameters.install_path >>/bin:$PATH' >> $BASH_ENV
+        echo "export PATH=<< parameters.install_path >>/bin:$PATH" >> $BASH_ENV


### PR DESCRIPTION
This should be safer for expanding environment variables than single quotes