### PR TITLE
Place Elixir into local path when installing

### DIFF
--- a/src/commands/install-elixir.yml
+++ b/src/commands/install-elixir.yml
@@ -11,4 +11,7 @@ steps:
       command: |
         wget https://repo.hex.pm/builds/elixir/v<< parameters.version >>.zip
         unzip -d << parameters.install_path >> v<< parameters.version >>.zip
-        echo "export PATH=<< parameters.install_path >>/bin:$PATH" >> $BASH_ENV
+        ln -s "<< parameters.install_path >>/bin/iex" $HOME/bin/iex
+        ln -s "<< parameters.install_path >>/bin/mix" $HOME/bin/mix
+        ln -s "<< parameters.install_path >>/bin/elixir" $HOME/bin/elixir
+        ln -s "<< parameters.install_path >>/bin/elixirc" $HOME/bin/elixirc


### PR DESCRIPTION
This removes the need to add the `$HOME/elixir/bin` directory to the
PATH. It will just work thanks to symlinks.

This also fixes an odd issue when building libnl where Buildroot's host
path would get dropped when running commands. This broke the calls to
run `flex` and `bison`, but it could have been others.
